### PR TITLE
Fix Links in Syllabus

### DIFF
--- a/pages/old_syllabus/cs199_fa18.md
+++ b/pages/old_syllabus/cs199_fa18.md
@@ -1,6 +1,4 @@
 ---
-permalink: courses/cs199_fa18
-
 header: Real World Cases in Scientific Computing  (CS 199)
 ---
 

--- a/pages/old_syllabus/cs199_fa19.md
+++ b/pages/old_syllabus/cs199_fa19.md
@@ -1,6 +1,4 @@
 ---
-permalink: courses/cs199_fa19
-
 header: Brushing up linear algebra and programming skills using Python (CS 199)
 ---
 

--- a/pages/old_syllabus/cs199py_fa19.md
+++ b/pages/old_syllabus/cs199py_fa19.md
@@ -1,6 +1,4 @@
 ---
-permalink: courses/cs199py_fa19
-
 header: Python for Data  (CS 199)
 ---
 ## Description

--- a/pages/teaching.md
+++ b/pages/teaching.md
@@ -44,15 +44,15 @@ I have taught eight different undergraduate courses with over 4700 students, fro
     </tr>
     <tr>
       <td> Brushing up linear algebra and programming skills using Python </td>
-      <td> <a href="{{ site.baseurl }}/pages/old_syllabus/cs199_fa19.md" target="blank">Fall 2019</a> </td>
+      <td> <a href="{{ site.baseurl }}/pages/old_syllabus/cs199_fa19.html" target="blank">Fall 2019</a> </td>
     </tr>
     <tr>
       <td> Python for Data </td>
-      <td> <a href="{{ site.baseurl }}/pages/old_syllabus/cs199py_fa19.md" target="blank">Fall 2019</a> </td>
+      <td> <a href="{{ site.baseurl }}/pages/old_syllabus/cs199py_fa19.html" target="blank">Fall 2019</a> </td>
     </tr>
     <tr>
       <td> Real World Cases in Scientific Computing </td>
-      <td> <a href="{{ site.baseurl }}/pages/old_syllabus/cs199_fa18.md" target="blank">Fall 2018</a> </td>
+      <td> <a href="{{ site.baseurl }}/pages/old_syllabus/cs199_fa18.html" target="blank">Fall 2018</a> </td>
     </tr>
     <tr>
       <td> Introduction to Online Learning Systems </td>


### PR DESCRIPTION
The code was super, super close -- the root problem was that your old syllabus had a `permalink` header that asked Jekyll to place the pages in non-default locations.

I removed the `permalink`, which then allows Jekyll to generate the HTML pages in the expected location.  The last change was to change `.md` to `.html` since Jekyll generates `.html` from `.md`.  It now works! 🎉 

Since I removed the `permalink`, you may want to verify no other page was expecting that page in a specific location (I might have broken something else, but I couldn't find anywhere that it might be broken).